### PR TITLE
Ensuring that no flash of the shadow happens on the page.

### DIFF
--- a/partials/topbar.hbs
+++ b/partials/topbar.hbs
@@ -21,3 +21,6 @@
         </div>
     </div>
 </nav>
+<script type="text/javascript">
+    document.getElementById('top-bar').classList.remove('scroll_shadow')
+</script>


### PR DESCRIPTION
The scroll-shadow is added/removed by javascript, before javascript is loaded the page will show the shadow for a flash of a second on firefox.

Signed-off-by: Martin Heidegger <martin.heidegger@gmail.com>