### PR TITLE
Fixing inconsistent state when clicking the menu to quickly in mobile mode.

### DIFF
--- a/assets/main/js/topbar.js
+++ b/assets/main/js/topbar.js
@@ -9,7 +9,6 @@
         element.classList.toggle('scroll_shadow', isScrolledToTop || (hasDropDown && isDropdownExpanded));
     }
 
-    $(document).on('click.bs.button.data-api', scrollShadow);
-    $(document).ready(scrollShadow);
+    $(document).on('click.bs.button.data-api ready', scrollShadow);
     $(window).on('scroll resize', scrollShadow);
 })()

--- a/assets/main/js/topbar.js
+++ b/assets/main/js/topbar.js
@@ -1,17 +1,18 @@
-const scrollShadow = function(clicked) {
-    let element = document.getElementById("top-bar");
-    if (clicked == true && window.pageYOffset < 40) {
-         element.classList.toggle('scroll_shadow');
-    } else {
-        window.pageYOffset > 40 || document.getElementById('navbarSupportedContent').classList.contains('show') ? element.classList.add('scroll_shadow') : element.classList.remove('scroll_shadow');
+(function () {
+    const scrollShadow = function(clicked) {
+        let element = document.getElementById("top-bar");
+        if (clicked == true && window.pageYOffset < 40) {
+            element.classList.toggle('scroll_shadow');
+        } else {
+            window.pageYOffset > 40 || document.getElementById('navbarSupportedContent').classList.contains('show') ? element.classList.add('scroll_shadow') : element.classList.remove('scroll_shadow');
+        }
     }
-}
 
-document.getElementById('toggle-button').addEventListener("click", function() {
-    scrollShadow(true)
-});
+    document.getElementById('toggle-button').addEventListener("click", function() {
+        scrollShadow(true)
+    });
 
-$(document).ready(scrollShadow);
+    $(document).ready(scrollShadow);
 
-$(window).scroll(scrollShadow);
-
+    $(window).scroll(scrollShadow);
+})()

--- a/assets/main/js/topbar.js
+++ b/assets/main/js/topbar.js
@@ -1,18 +1,15 @@
 (function () {
-    const scrollShadow = function(clicked) {
-        let element = document.getElementById("top-bar");
-        if (clicked == true && window.pageYOffset < 40) {
-            element.classList.toggle('scroll_shadow');
-        } else {
-            window.pageYOffset > 40 || document.getElementById('navbarSupportedContent').classList.contains('show') ? element.classList.add('scroll_shadow') : element.classList.remove('scroll_shadow');
-        }
+    const element = document.getElementById("top-bar");
+    const toggleButton = document.getElementById('toggle-button');
+
+    const scrollShadow = function () {
+        const isScrolledToTop = window.pageYOffset > 40;
+        const hasDropDown = document.body.offsetWidth < 768;
+        const isDropdownExpanded = !toggleButton.classList.contains('collapsed');
+        element.classList.toggle('scroll_shadow', isScrolledToTop || (hasDropDown && isDropdownExpanded));
     }
 
-    document.getElementById('toggle-button').addEventListener("click", function() {
-        scrollShadow(true)
-    });
-
+    $(document).on('click.bs.button.data-api', scrollShadow);
     $(document).ready(scrollShadow);
-
-    $(window).scroll(scrollShadow);
+    $(window).on('scroll resize', scrollShadow);
 })()

--- a/partials/topbar.hbs
+++ b/partials/topbar.hbs
@@ -3,7 +3,7 @@
         <header class="major" id="header">
             <a href="{{@site.url}}" class="{{#if @site.logo}}image{{/if}}">{{#if @site.logo}}<img src="{{asset "images/logo/consento-with-text.png"}}" class="img-fluid navbar-brand " alt="{{@site.title}}" />{{/if}}</a>
         </header>
-        <button id="toggle-button" class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button id="toggle-button" class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         


### PR DESCRIPTION
Using following techniques:
- 'click.bs.button.data-api' is triggered by bootstrap when the trigger button is clicked and at that point the class "collapsed" is changed, giving a correct time and state for the toggle button
- Using document.body.offsetWidth and the resize event to make sure that the menu is not visible

↓ Recording of the error showing up when clicking to quickly (state before this PR)
[Screen Recording 2020-02-26 at 23.36.57.zip](https://github.com/consento-org/consento-website/files/4256273/Screen.Recording.2020-02-26.at.23.36.57.zip)

Close #69 


